### PR TITLE
Allow nginx-updater to see /letsencrypt

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,7 @@ services:
     restart: always
     volumes:
       - nginx-config:/nginx-config
+      - letsencrypt-data:/letsencrypt
     networks:
       - etcd-services
     depends_on:


### PR DESCRIPTION
This is required for csmith/docker-service-nginx#3